### PR TITLE
Export libTranslate Directly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,12 @@
   "name": "translate.js",
   "version": "1.1.0",
   "description": "Javascript micro library for translations (i18n) with support for placeholders and multiple plural forms.",
-  "main": "Gruntfile.js",
+  "main": "src/translate.js",
   "dependencies": {
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-contrib-jasmine": "~0.6.0",
-    "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-copy": "~0.5.0"
   },
   "scripts": {
-    "test": "grunt test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,15 @@
   "dependencies": {
   },
   "devDependencies": {
+    "grunt": "~0.4.4",
+    "grunt-contrib-jasmine": "~0.6.0",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-uglify": "~0.4.0",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-copy": "~0.5.0"
   },
   "scripts": {
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",

--- a/src/translate.js
+++ b/src/translate.js
@@ -10,15 +10,15 @@
  *       translationKey: 'value123'
  *   }
  * }
- * 
+ *
  * var options = {
  *     // These are the defaults:
  *     debug: false, //[Boolean]: Logs missing translations to console and adds @@-markers around output.
  *     namespaceSplitter: '::' //[String|RegExp]: You can customize the part which splits namespace and translationKeys.
  * }
- * 
+ *
  * var t = libTranslate.getTranslationFunction(messages, [options])
- * 
+ *
  * t('translationKey')
  * t('translationKey', count)
  * t('translationKey', {replaceKey: 'replacevalue'})
@@ -31,15 +31,14 @@
  * @licence May be freely distributed under the MIT license.
  */
 
-/*global window, console */
-;(function () {
+module.exports = function () {
     'use strict';
 
     var isNumeric = function(obj) { return !isNaN(parseFloat(obj)) && isFinite(obj); };
     var isObject = function(obj) { return typeof obj === 'object' && obj !== null; };
     var isString = function(obj) { return Object.prototype.toString.call(obj) === '[object String]'; };
 
-    window.libTranslate = {
+    function libTranslate() {
         getTranslationFunction: function(messageObject, options) {
             options = isObject(options) ? options : {};
 
@@ -54,7 +53,7 @@
                 var components = translationKey.split(namespaceSplitter); //@todo make this more robust. maybe support more levels?
                 var namespace = components[0];
                 var key = components[1];
-             
+
                 if(messageObject[namespace] && messageObject[namespace][key]) {
                     return messageObject[namespace][key];
                 }
@@ -137,4 +136,4 @@
             };
         }
     };
-})();
+};

--- a/src/translate.js
+++ b/src/translate.js
@@ -31,109 +31,109 @@
  * @licence May be freely distributed under the MIT license.
  */
 
-module.exports = function () {
-    'use strict';
+'use strict';
 
-    var isNumeric = function(obj) { return !isNaN(parseFloat(obj)) && isFinite(obj); };
-    var isObject = function(obj) { return typeof obj === 'object' && obj !== null; };
-    var isString = function(obj) { return Object.prototype.toString.call(obj) === '[object String]'; };
+var isNumeric = function(obj) { return !isNaN(parseFloat(obj)) && isFinite(obj); };
+var isObject = function(obj) { return typeof obj === 'object' && obj !== null; };
+var isString = function(obj) { return Object.prototype.toString.call(obj) === '[object String]'; };
 
-    function libTranslate() {
-        getTranslationFunction: function(messageObject, options) {
-            options = isObject(options) ? options : {};
+var libTranslate = {
+    getTranslationFunction: function(messageObject, options) {
+        options = isObject(options) ? options : {};
 
-            var debug = options.debug;
-            var namespaceSplitter = options.namespaceSplitter || '::';
+        var debug = options.debug;
+        var namespaceSplitter = options.namespaceSplitter || '::';
 
-            function getTranslationValue(translationKey) {
-                if(messageObject[translationKey]) {
-                    return messageObject[translationKey];
-                }
-
-                var components = translationKey.split(namespaceSplitter); //@todo make this more robust. maybe support more levels?
-                var namespace = components[0];
-                var key = components[1];
-
-                if(messageObject[namespace] && messageObject[namespace][key]) {
-                    return messageObject[namespace][key];
-                }
-
-                return null;
+        function getTranslationValue(translationKey) {
+            if(messageObject[translationKey]) {
+                return messageObject[translationKey];
             }
 
-            function getPluralValue(translation, count) {
-                if (isObject(translation)) {
-                    var keys = Object.keys(translation);
-                    var upperCap;
+            var components = translationKey.split(namespaceSplitter); //@todo make this more robust. maybe support more levels?
+            var namespace = components[0];
+            var key = components[1];
 
-                    if(keys.length === 0) {
-                        debug && console.log('[Translation] No plural forms found.');
-                        return null;
-                    }
-
-                    for(var i = 0; i < keys.length; i++) {
-                        if(keys[i].indexOf('gt') === 0) {
-                            upperCap = parseInt(keys[i].replace('gt', ''), 10);
-                        }
-                    }
-
-                    if(translation[count]){
-                        translation = translation[count];
-                    } else if(count > upperCap) { //int > undefined returns false
-                        translation = translation['gt' + upperCap];
-                    } else if(translation.n) {
-                        translation = translation.n;
-                    } else {
-                        debug && console.log('[Translation] No plural forms found for count:"' + count + '" in', translation);
-                        translation = translation[Object.keys(translation).reverse()[0]];
-                    }
-                }
-
-                return translation;
+            if(messageObject[namespace] && messageObject[namespace][key]) {
+                return messageObject[namespace][key];
             }
 
-            function replacePlaceholders(translation, replacements) {
-                if (isString(translation)) {
-                    return translation.replace(/\{(\w*)\}/g, function (match, key) {
-                        if(!replacements.hasOwnProperty(key)) {
-                            debug && console.log('Could not find replacement "' + key + '" in provided replacements object:', replacements);
-
-                            return '{' + key + '}';
-                        }
-
-                        return replacements.hasOwnProperty(key) ? replacements[key] : key;
-                    });
-                }
-
-                return translation;
-            }
-
-            return function (translationKey) {
-                var replacements = isObject(arguments[1]) ? arguments[1] : (isObject(arguments[2]) ? arguments[2] : {});
-                var count = isNumeric(arguments[1]) ? arguments[1] : (isNumeric(arguments[2]) ? arguments[2] : null);
-
-                var translation = getTranslationValue(translationKey);
-
-                if (count !== null) {
-                    replacements.n = replacements.n ? replacements.n : count;
-
-                    //get appropriate plural translation string
-                    translation = getPluralValue(translation, count);
-                }
-
-                //replace {placeholders}
-                translation = replacePlaceholders(translation, replacements);
-
-                if (translation === null) {
-                    translation = debug ? '@@' + translationKey + '@@' : translationKey;
-
-                    if (debug) {
-                        console.log('Translation for "' + translationKey + '" not found.');
-                    }
-                }
-
-                return translation;
-            };
+            return null;
         }
-    };
+
+        function getPluralValue(translation, count) {
+            if (isObject(translation)) {
+                var keys = Object.keys(translation);
+                var upperCap;
+
+                if(keys.length === 0) {
+                    debug && console.log('[Translation] No plural forms found.');
+                    return null;
+                }
+
+                for(var i = 0; i < keys.length; i++) {
+                    if(keys[i].indexOf('gt') === 0) {
+                        upperCap = parseInt(keys[i].replace('gt', ''), 10);
+                    }
+                }
+
+                if(translation[count]){
+                    translation = translation[count];
+                } else if(count > upperCap) { //int > undefined returns false
+                    translation = translation['gt' + upperCap];
+                } else if(translation.n) {
+                    translation = translation.n;
+                } else {
+                    debug && console.log('[Translation] No plural forms found for count:"' + count + '" in', translation);
+                    translation = translation[Object.keys(translation).reverse()[0]];
+                }
+            }
+
+            return translation;
+        }
+
+        function replacePlaceholders(translation, replacements) {
+            if (isString(translation)) {
+                return translation.replace(/\{(\w*)\}/g, function (match, key) {
+                    if(!replacements.hasOwnProperty(key)) {
+                        debug && console.log('Could not find replacement "' + key + '" in provided replacements object:', replacements);
+
+                        return '{' + key + '}';
+                    }
+
+                    return replacements.hasOwnProperty(key) ? replacements[key] : key;
+                });
+            }
+
+            return translation;
+        }
+
+        return function (translationKey) {
+            var replacements = isObject(arguments[1]) ? arguments[1] : (isObject(arguments[2]) ? arguments[2] : {});
+            var count = isNumeric(arguments[1]) ? arguments[1] : (isNumeric(arguments[2]) ? arguments[2] : null);
+
+            var translation = getTranslationValue(translationKey);
+
+            if (count !== null) {
+                replacements.n = replacements.n ? replacements.n : count;
+
+                //get appropriate plural translation string
+                translation = getPluralValue(translation, count);
+            }
+
+            //replace {placeholders}
+            translation = replacePlaceholders(translation, replacements);
+
+            if (translation === null) {
+                translation = debug ? '@@' + translationKey + '@@' : translationKey;
+
+                if (debug) {
+                    console.log('Translation for "' + translationKey + '" not found.');
+                }
+            }
+
+            return translation;
+        };
+    }
 };
+
+module.exports = libTranslate;


### PR DESCRIPTION
Export `libTranslate` directly. Package can be imported as `import libTranslate from 'translate.js'` for npm's node_modules.

Most of the changes to `src/translate.js` is indentation. The only real change was to change it from being on window scope to `libTranslate` being exported.
